### PR TITLE
Fix validateNickname AND findMembers

### DIFF
--- a/src/main/java/com/timecapsule/timecapsule/service/MemberService.java
+++ b/src/main/java/com/timecapsule/timecapsule/service/MemberService.java
@@ -21,18 +21,18 @@ public class MemberService {
      */
     @Transactional
     public Long join(Member member){
-        validateDuplicateNickname(member);
+        validateNickname(member);
         validateDuplicateEmail(member);
         validateDuplicatePhoneNumber(member);
         memberRepository.save(member);
         return member.getId();
     }
 
-    //중복 닉네임 검증
-    private void validateDuplicateNickname(Member member){
-        List<Member> findMembers = memberRepository.findByNickname(member.getNickname());
-        if(!findMembers.isEmpty()){
-            throw new IllegalStateException("이미 존재하는 닉네임입니다.");
+    //닉네임 검증(글자수 제한, 8글자)
+    private void validateNickname(Member member){
+        int nicknameLength = member.getNickname().length();
+        if(nicknameLength <= 0 || nicknameLength > 9){
+            throw new IllegalStateException("올바른 닉네임이 아닙니다.");
         }
     }
 
@@ -72,11 +72,6 @@ public class MemberService {
     /**
      * 회원 조회
      */
-    //회원 전체 조회
-    public List<Member> findMembers(){
-        return memberRepository.findAll();
-    }
-
     //회원 개별 조회
     public Member findOne(Long memberId){
         return memberRepository.findOne(memberId);


### PR DESCRIPTION
Member service의 메소드인 전체조회를 삭제하고, 중복닉네임 검증을 닉네임 검증으로 바꿔서 8글자 제한을 검사하는 것으로 바꿨습니다.