### PR TITLE
Fix TimeCapsuleController to fix error

### DIFF
--- a/src/main/java/com/timecapsule/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/timecapsule/timecapsule/controller/TimeCapsuleController.java
@@ -77,7 +77,9 @@ public class TimeCapsuleController {
         
         session.removeAttribute("groupId");
         
-        multimediaService.createNewMultimedias(timeCapsuleId, multipartFiles);
+        if (!multipartFiles.get(0).getOriginalFilename().isEmpty()) {
+            multimediaService.createNewMultimedias(timeCapsuleId, multipartFiles);
+        }
         
         return "redirect:/";
     }


### PR DESCRIPTION
멀티미디어 파일을 삽입하지 않고 타입캡슐을 생성할 때 발생하는 500번 에러를 해결했습니다.